### PR TITLE
Add changes for home permissions

### DIFF
--- a/TaskSpaces/app/src/main/java/com/ucapdm2025/taskspaces/ui/screens/home/HomeScreen.kt
+++ b/TaskSpaces/app/src/main/java/com/ucapdm2025/taskspaces/ui/screens/home/HomeScreen.kt
@@ -42,6 +42,7 @@ import com.ucapdm2025.taskspaces.ui.components.general.FeedbackIcon
 import com.ucapdm2025.taskspaces.ui.components.general.FloatingStatusDialog
 import com.ucapdm2025.taskspaces.ui.components.general.NotificationHost
 import com.ucapdm2025.taskspaces.ui.components.home.HomeEditMode
+import com.ucapdm2025.taskspaces.ui.components.workspace.MemberRoles
 import com.ucapdm2025.taskspaces.ui.screens.home.sections.AssignedTasksSection
 import com.ucapdm2025.taskspaces.ui.screens.home.sections.SharedWorkspacesSection
 import com.ucapdm2025.taskspaces.ui.screens.home.sections.YourWorkspacesSection
@@ -238,19 +239,20 @@ fun HomeScreen(
                             YourWorkspacesSection(
                                 workspaces = state.data,
                                 onClickWorkspaceCard = { workspace ->
-//                            Set the selected workspace ID when in update mode and show the dialog
                                     when (editMode.value) {
                                         HomeEditMode.UPDATE -> {
-                                            viewModel.setSelectedWorkspaceId(workspace.id)
-                                            viewModel.setWorkspaceDialogData(workspace.title)
-                                            viewModel.showDialog()
+                                            if (viewModel.hasSufficientPermissions(workspace.id, MemberRoles.ADMIN)) {
+                                                viewModel.setSelectedWorkspaceId(workspace.id)
+                                                viewModel.setWorkspaceDialogData(workspace.title)
+                                                viewModel.showDialog()
+                                            }
                                         }
 
-                                        //                                Delete the workspace clicked when in delete mode
-//                                TODO: Add a confirmation dialog before deleting
                                         HomeEditMode.DELETE -> {
-                                            viewModel.deleteWorkspace(workspace.id)
-                                            viewModel.setEditMode(HomeEditMode.NONE)
+                                            if (viewModel.hasSufficientPermissions(workspace.id, MemberRoles.ADMIN)) {
+                                                viewModel.deleteWorkspace(workspace.id)
+                                                viewModel.setEditMode(HomeEditMode.NONE)
+                                            }
                                         }
 
                                         else -> onNavigateWorkspace(workspace.id)
@@ -368,7 +370,6 @@ fun HomeScreenLightPreview() {
         }
     }
 }
-
 
 /**
  * Preview of the HomeScreen in dark mode using theme colors.


### PR DESCRIPTION
- Added import statements for MemberRoles and MemberRoleRepository in both HomeScreen.kt and HomeViewModel.kt.
- Updated the HomeScreen to check if a user has sufficient permissions (specifically ADMIN role) before allowing them to update or delete a workspace. This is done by calling viewModel.hasSufficientPermissions with the workspace id and required role.
- Added the hasSufficientPermissions function to HomeViewModel. This function uses MemberRoleRepository to check if the current user’s role in a workspace meets the minimum required role.
- Injected MemberRoleRepository into HomeViewModel and updated the ViewModel’s factory to provide this dependency.
- Cleaned up some comments and formatting.