### PR TITLE
Feature/ts 295 : Confirm dialog to delete workspaces, projects.

### DIFF
--- a/TaskSpaces/app/src/main/java/com/ucapdm2025/taskspaces/ui/screens/home/HomeViewModel.kt
+++ b/TaskSpaces/app/src/main/java/com/ucapdm2025/taskspaces/ui/screens/home/HomeViewModel.kt
@@ -73,6 +73,12 @@ class HomeViewModel(
         _wasCreateAttempted.value = value
     }
 
+    private val _showDeleteConfirmationDialog: MutableStateFlow<Boolean> = MutableStateFlow(false)
+    val showDeleteConfirmationDialog: StateFlow<Boolean> = _showDeleteConfirmationDialog.asStateFlow()
+
+    private val _pendingWorkspaceToDeleteId: MutableStateFlow<Int?> = MutableStateFlow(null)
+    val pendingWorkspaceToDeleteId: StateFlow<Int?> = _pendingWorkspaceToDeleteId.asStateFlow()
+
     //    Fetch user id from auth
     init {
         viewModelScope.launch {
@@ -230,6 +236,16 @@ class HomeViewModel(
 
     fun setSelectedWorkspaceId(id: Int?) {
         _selectedWorkspaceId.value = id
+    }
+    // Delete confirmation dialog functions
+    fun showDeleteConfirmationDialog(workspaceId: Int) {
+        _pendingWorkspaceToDeleteId.value = workspaceId
+        _showDeleteConfirmationDialog.value = true
+    }
+
+    fun hideDeleteConfirmationDialog() {
+        _pendingWorkspaceToDeleteId.value = null
+        _showDeleteConfirmationDialog.value = false
     }
 
     fun hasSufficientPermissions(

--- a/TaskSpaces/app/src/main/java/com/ucapdm2025/taskspaces/ui/screens/workspace/WorkspaceViewModel.kt
+++ b/TaskSpaces/app/src/main/java/com/ucapdm2025/taskspaces/ui/screens/workspace/WorkspaceViewModel.kt
@@ -98,6 +98,12 @@ class WorkspaceViewModel(
         _wasInviteAttempted.value = value
     }
 
+    private val _showProjectDeleteConfirmationDialog: MutableStateFlow<Boolean> = MutableStateFlow(false)
+    val showProjectDeleteConfirmationDialog: StateFlow<Boolean> = _showProjectDeleteConfirmationDialog.asStateFlow()
+
+    private val _pendingProjectToDeleteId: MutableStateFlow<Int?> = MutableStateFlow(null)
+    val pendingProjectToDeleteId: StateFlow<Int?> = _pendingProjectToDeleteId.asStateFlow()
+
 
     init {
 //        Get current workspace info
@@ -230,10 +236,21 @@ class WorkspaceViewModel(
         _selectedProjectId.value = projectId
     }
 
+    fun showProjectDeleteConfirmationDialog(projectId: Int) {
+        _pendingProjectToDeleteId.value = projectId
+        _showProjectDeleteConfirmationDialog.value = true
+    }
+
+    fun hideProjectDeleteConfirmationDialog() {
+        _pendingProjectToDeleteId.value = null
+        _showProjectDeleteConfirmationDialog.value = false
+    }
+
     //    Manage members dialog functions
     fun showManageMembersDialog() {
         _showManageMembersDialog.value = true
     }
+
 
     fun hideManageMembersDialog() {
         _showManageMembersDialog.value = false


### PR DESCRIPTION
This pull request implements a confirmation dialog to delete workspaces, projects.
The changes include:

- HomeScreen.kt: Added the confirmation dialog.
- HomeViewModel.kt: Implemented the logic to trigger the confirmation dialog before executing delete operations.
- WorkspaceScreen.kt: Introduced the confirmation dialog in the workspace screen.
- WorkspaceViewModel.kt: Updated the ViewModel to handle delete actions with the new confirmation dialog logic.

#### Note: The confirmation dialog has not been implemented for tasks due to the absence of a deleted function required for task deletion.
